### PR TITLE
Update README.md with correct package name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Install either [TeX Live](https://www.tug.org/texlive/) or [MiKTeX](https://mikt
 
 You may also need to install one or more of the following:
 * `biber`
-* `pygmentize` (via pip)
+* `Pygments` (via pip)
 * `fvextra`
 
 Make sure that these are accessible via the terminal.


### PR DESCRIPTION
Rename `pygmentize` to `Pygments` as the former is an invalid package in pip.